### PR TITLE
Add chat mode selector and auto-fill student ID

### DIFF
--- a/app/api/chat/gemini/route.ts
+++ b/app/api/chat/gemini/route.ts
@@ -185,10 +185,24 @@ export async function POST(req: Request) {
 
     // Mode handling: club (force KB), domain (force Gemini), auto (decide)
     if (mode === 'club') {
-      const hit = matchClubFaq(message)
-      const raw = hit && typeof hit === 'string' && hit.trim() ? hit : 'Thông tin hiện chưa có trong dữ liệu FTC.'
-      const answer = sanitizeText(raw)
-      return new Response(JSON.stringify({ response: answer, source: 'club' }), { headers: { 'Content-Type': 'application/json' } })
+      // Try direct club FAQ match first, then fallback to backend knowledge base summary
+      let answer: string | null = null
+      try {
+        const hit = matchClubFaq(message)
+        if (typeof hit === 'string' && hit.trim()) answer = hit
+      } catch (e) {}
+
+      if (!answer && backendContext) {
+        const q = message.toLowerCase()
+        const idx = backendContext.toLowerCase().indexOf(q.split(' ')[0] || '')
+        if (idx >= 0) {
+          const snippet = backendContext.slice(Math.max(0, idx - 200), Math.min(backendContext.length, idx + 600))
+          answer = `Thông tin tham khảo từ dữ liệu CLB: ${snippet}`
+        }
+      }
+
+      if (!answer) answer = 'Thông tin hiện chưa có trong dữ liệu FTC.'
+      return new Response(JSON.stringify({ response: sanitizeText(answer), source: 'club', backendContext }), { headers: { 'Content-Type': 'application/json' } })
     }
 
     if (mode === 'auto' && (suggested.matched || clubMatch)) {

--- a/app/api/chat/gemini/route.ts
+++ b/app/api/chat/gemini/route.ts
@@ -1,5 +1,4 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
-import { GoogleGenerativeAI } from "@google/generative-ai";
 import { matchSuggestedQuestion, buildGroundedPrompt } from '@/lib/faq-grounding'
 import { matchClubFaq, buildClubContextBlock, shouldRouteToIndustry } from '@/lib/club-faq'
 import { RECRUITMENT_CONFIG } from '@/app/ung-tuyen/constants'

--- a/app/chatbot/_components/chat-interface.tsx
+++ b/app/chatbot/_components/chat-interface.tsx
@@ -90,12 +90,37 @@ export function ChatInterface() {
         <div ref={messagesEndRef} />
       </CardContent>
 
-      <ChatInput
-        value={inputValue}
-        onChange={setInputValue}
-        onSend={handleSendMessage}
-        onKeyDown={handleKeyDown}
-      />
+      <div className="border-t border-accent/20 p-0 bg-gradient-to-r from-background/80 via-accent/5 to-background/80 backdrop-blur-md sticky bottom-0 mt-auto">
+        <ChatInput
+          value={inputValue}
+          onChange={setInputValue}
+          onSend={handleSendMessage}
+          onKeyDown={handleKeyDown}
+        />
+        <div className="max-w-full px-4 py-3 flex items-center justify-center gap-3 bg-card/40 border-t border-accent/10">
+          <span className="text-sm text-muted-foreground mr-2">Chế độ:</span>
+          <div className="inline-flex rounded-md bg-card/50 p-0.5 border border-accent/10">
+            <button
+              onClick={() => setMode('club')}
+              className={`px-3 py-1 text-xs rounded-md transition-colors duration-200 ${mode === 'club' ? 'bg-accent/20 text-foreground' : 'hover:bg-accent/10 text-muted-foreground'}`}
+            >
+              Hỏi về câu lạc bộ
+            </button>
+            <button
+              onClick={() => setMode('domain')}
+              className={`px-3 py-1 text-xs rounded-md transition-colors duration-200 ${mode === 'domain' ? 'bg-accent/20 text-foreground' : 'hover:bg-accent/10 text-muted-foreground'}`}
+            >
+              Hỏi về ngành
+            </button>
+            <button
+              onClick={() => setMode('auto')}
+              className={`px-3 py-1 text-xs rounded-md transition-colors duration-200 ${mode === 'auto' ? 'bg-accent/20 text-foreground' : 'hover:bg-accent/10 text-muted-foreground'}`}
+            >
+              Tự động
+            </button>
+          </div>
+        </div>
+      </div>
     </Card>
   )
 }

--- a/app/chatbot/_components/chat-interface.tsx
+++ b/app/chatbot/_components/chat-interface.tsx
@@ -8,7 +8,6 @@ import { ChatMessage } from "./chat-message"
 import { useChat } from "../_hooks/use-chat"
 import { useChatScroll } from "../_hooks/use-chat-scroll"
 import type { Message } from "@/app/chatbot/_lib/types"
-import "../types/react"
 
 export function ChatInterface() {
   const { messages, isTyping, inputValue, setInputValue, handleSendMessage, handleKeyDown } = useChat()

--- a/app/chatbot/_components/chat-interface.tsx
+++ b/app/chatbot/_components/chat-interface.tsx
@@ -1,24 +1,14 @@
 "use client"
 
 import { Bot } from "lucide-react"
-import PropTypes from "prop-types"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { ChatInput } from "./chat-input"
 import { ChatMessage } from "./chat-message"
 import { useChat } from "../_hooks/use-chat"
-import { useChatScroll } from "../_hooks/use-chat-scroll"
-
-import { FC } from 'react'
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Bot } from "lucide-react"
+import { useChatScroll } from "..//_hooks/use-chat-scroll"
 import type { Message } from "@/app/chatbot/_lib/types"
-import { ChatInput } from "./chat-input"
-import { ChatMessage } from "./chat-message"
-import { useChat } from "@/app/chatbot/_hooks/use-chat"
-import { useChatScroll } from "@/app/chatbot/_hooks/use-chat-scroll"
-import '../types/react'
+import "../types/react"
 
 export function ChatInterface() {
   const { messages, isTyping, inputValue, setInputValue, handleSendMessage, handleKeyDown } = useChat()

--- a/app/chatbot/_components/chat-interface.tsx
+++ b/app/chatbot/_components/chat-interface.tsx
@@ -25,6 +25,14 @@ export function ChatInterface() {
 
       <CardHeader className="relative z-10 border-b border-accent/20">
         <div className="flex items-center space-x-3">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-4">
+            <div className="flex items-center space-x-2">
+              <label className="text-sm font-medium">Chế độ:</label>
+              <div className="inline-flex rounded-md bg-card/50 p-0.5 border border-accent/10">
+                <button data-mode="club" className="px-3 py-1 text-xs rounded-md transition-colors duration-200 hover:bg-accent/10" />
+              </div>
+            </div>
+          </div>
           <Avatar>
             <AvatarImage src="/ai-chatbot-avatar.png" alt="AI Assistant" />
             <AvatarFallback className="bg-primary text-primary-foreground">

--- a/app/chatbot/_components/chat-interface.tsx
+++ b/app/chatbot/_components/chat-interface.tsx
@@ -29,7 +29,18 @@ export function ChatInterface() {
             <div className="flex items-center space-x-2">
               <label className="text-sm font-medium">Chế độ:</label>
               <div className="inline-flex rounded-md bg-card/50 p-0.5 border border-accent/10">
-                <button data-mode="club" className="px-3 py-1 text-xs rounded-md transition-colors duration-200 hover:bg-accent/10" />
+                <button
+                  onClick={() => setMode('club')}
+                  className={`px-3 py-1 text-xs rounded-md transition-colors duration-200 ${mode === 'club' ? 'bg-accent/20 text-foreground' : 'hover:bg-accent/10 text-muted-foreground'}`}
+                >
+                  Hỏi về câu lạc bộ
+                </button>
+                <button
+                  onClick={() => setMode('domain')}
+                  className={`px-3 py-1 text-xs rounded-md transition-colors duration-200 ${mode === 'domain' ? 'bg-accent/20 text-foreground' : 'hover:bg-accent/10 text-muted-foreground'}`}
+                >
+                  Hỏi về ngành
+                </button>
               </div>
             </div>
           </div>

--- a/app/chatbot/_components/chat-interface.tsx
+++ b/app/chatbot/_components/chat-interface.tsx
@@ -25,26 +25,7 @@ export function ChatInterface() {
 
       <CardHeader className="relative z-10 border-b border-accent/20">
         <div className="flex items-center space-x-3">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-4">
-            <div className="flex items-center space-x-2">
-              <label className="text-sm font-medium">Chế độ:</label>
-              <div className="inline-flex rounded-md bg-card/50 p-0.5 border border-accent/10">
-                <button
-                  onClick={() => setMode('club')}
-                  className={`px-3 py-1 text-xs rounded-md transition-colors duration-200 ${mode === 'club' ? 'bg-accent/20 text-foreground' : 'hover:bg-accent/10 text-muted-foreground'}`}
-                >
-                  Hỏi về câu lạc bộ
-                </button>
-                <button
-                  onClick={() => setMode('domain')}
-                  className={`px-3 py-1 text-xs rounded-md transition-colors duration-200 ${mode === 'domain' ? 'bg-accent/20 text-foreground' : 'hover:bg-accent/10 text-muted-foreground'}`}
-                >
-                  Hỏi về ngành
-                </button>
-              </div>
-            </div>
-          </div>
-          <Avatar>
+            <Avatar>
             <AvatarImage src="/ai-chatbot-avatar.png" alt="AI Assistant" />
             <AvatarFallback className="bg-primary text-primary-foreground">
               <Bot className="h-5 w-5" />

--- a/app/chatbot/_components/chat-interface.tsx
+++ b/app/chatbot/_components/chat-interface.tsx
@@ -6,7 +6,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { ChatInput } from "./chat-input"
 import { ChatMessage } from "./chat-message"
 import { useChat } from "../_hooks/use-chat"
-import { useChatScroll } from "..//_hooks/use-chat-scroll"
+import { useChatScroll } from "../_hooks/use-chat-scroll"
 import type { Message } from "@/app/chatbot/_lib/types"
 import "../types/react"
 

--- a/app/chatbot/_components/chat-interface.tsx
+++ b/app/chatbot/_components/chat-interface.tsx
@@ -10,7 +10,7 @@ import { useChatScroll } from "../_hooks/use-chat-scroll"
 import type { Message } from "@/app/chatbot/_lib/types"
 
 export function ChatInterface() {
-  const { messages, isTyping, inputValue, setInputValue, handleSendMessage, handleKeyDown } = useChat()
+  const { messages, isTyping, inputValue, setInputValue, handleSendMessage, handleKeyDown, mode, setMode } = useChat()
   const messagesEndRef = useChatScroll(messages)
 
   return (

--- a/app/chatbot/_hooks/use-chat.js
+++ b/app/chatbot/_hooks/use-chat.js
@@ -8,6 +8,7 @@ export function useChat() {
   const [messages, setMessages] = useState([])
   const [isTyping, setIsTyping] = useState(false)
   const [inputValue, setInputValue] = useState("")
+  const [mode, setMode] = useState('auto')
   const abortControllerRef = useRef(null)
 
   const handleSendMessage = useCallback(async () => {
@@ -36,7 +37,7 @@ export function useChat() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ message: userMessage.content }),
+        body: JSON.stringify({ message: userMessage.content, mode }),
         signal: abortControllerRef.current.signal,
       })
 
@@ -73,7 +74,7 @@ export function useChat() {
     } finally {
       setIsTyping(false)
     }
-  }, [inputValue])
+  }, [inputValue, mode])
 
   const handleKeyDown = useCallback(
     (event) => {
@@ -92,5 +93,7 @@ export function useChat() {
     setInputValue,
     handleSendMessage,
     handleKeyDown,
+    mode,
+    setMode,
   }
 }

--- a/app/chatbot/_hooks/use-chat.ts
+++ b/app/chatbot/_hooks/use-chat.ts
@@ -21,6 +21,7 @@ export function useChat() {
   ])
   const [inputValue, setInputValue] = useState("")
   const [isTyping, setIsTyping] = useState(false)
+  const [mode, setMode] = useState<'auto' | 'club' | 'domain'>('auto')
 
   const isSendingRef = { current: false }
   const lastSentRef = { current: { text: "", time: 0 } }
@@ -67,9 +68,10 @@ export function useChat() {
       const res = await fetch("/api/chat/gemini", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ 
-          message: text, 
-          history
+        body: JSON.stringify({
+          message: text,
+          history,
+          mode: mode === 'club' ? 'club' : (mode === 'domain' ? 'domain' : 'auto')
         }),
       })
 
@@ -119,5 +121,7 @@ export function useChat() {
     setInputValue,
     handleSendMessage,
     handleKeyDown,
+    mode,
+    setMode,
   }
 }

--- a/app/dien-dan/components/cards/ask-question-card.tsx
+++ b/app/dien-dan/components/cards/ask-question-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'

--- a/app/dien-dan/components/cards/ask-question-card.tsx
+++ b/app/dien-dan/components/cards/ask-question-card.tsx
@@ -27,6 +27,13 @@ export function AskQuestionCard({
   const [error, setError] = useState('')
   const [mode, setMode] = useState<'anonymous' | 'mssv'>('anonymous')
 
+  useEffect(() => {
+    // When switching to mssv mode, auto-fill from currentStudentId if available
+    if (mode === 'mssv' && !studentId && currentStudentId) {
+      setStudentId(currentStudentId)
+    }
+  }, [mode, currentStudentId, studentId])
+
   function validate() {
     if (!title.trim() || !content.trim()) {
       setError('Vui lòng nhập đầy đủ tiêu đề và nội dung')

--- a/app/dien-dan/components/cards/question-card.tsx
+++ b/app/dien-dan/components/cards/question-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'

--- a/app/dien-dan/components/cards/question-card.tsx
+++ b/app/dien-dan/components/cards/question-card.tsx
@@ -29,6 +29,12 @@ export function QuestionCard({
   const [replyMode, setReplyMode] = useState<'anonymous' | 'mssv'>('anonymous')
   const [replyStudentId, setReplyStudentId] = useState('')
 
+  useEffect(() => {
+    if (replyMode === 'mssv' && !replyStudentId && defaultStudentId) {
+      setReplyStudentId(defaultStudentId)
+    }
+  }, [replyMode, defaultStudentId, replyStudentId])
+
   const authorDisplay = q.studentId ? q.studentId : 'Ẩn danh'
 
   return (

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -20,7 +20,7 @@ const navigationItems: NavigationItem[] = [
   { name: "Cơ cấu", href: "/co-cau", icon: Shield },
   { name: "Diễn đàn", href: "/dien-dan", icon: Zap },
   { name: "Ứng tuyển", href: "/ung-tuyen", icon: Cpu },
-  { name: "Chatbot", href: "/chatbot", icon: Zap },
+  { name: "Chatbot", href: "/chatbot", icon: Bot },
 ]
 
 export function Navigation() {

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
-import { Menu, X, Zap, Shield, Cpu, Info } from 'lucide-react'
+import { Menu, X, Zap, Shield, Cpu, Info, Bot } from 'lucide-react'
 import Image from 'next/image'
 
 interface NavigationItem {


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements two key improvements:
1. **Chat mode selector**: Users requested a mode selection feature for the chatbot to choose between asking about clubs vs. academic fields, positioned below the input field with better design
2. **Auto-fill student ID**: Users wanted automatic population of student ID from profile when switching to MSSV mode in forum posting/replying, eliminating the need to re-enter it each time

## Code changes

### Chat Interface Enhancements
- Added mode selector UI below chat input with three options: "Hỏi về câu lạc bộ", "Hỏi về ngành", "Tự động"
- Enhanced chat hook to manage mode state and pass it to API
- Improved club mode logic with fallback to backend knowledge base
- Updated styling with gradient background and better visual hierarchy

### Forum Auto-fill Feature
- Added `useEffect` hooks in question and reply cards to auto-populate student ID from profile
- Automatic filling occurs when switching to MSSV mode if current student ID is available
- Maintains existing manual input capability as fallback

### Code Quality
- Removed duplicate imports and unused dependencies
- Updated navigation icon for chatbot from generic Zap to Bot icon
- Cleaned up TypeScript types and component structureTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8a368916f5954036af3c9fd94aa2cf9c/aura-space)

👀 [Preview Link](https://8a368916f5954036af3c9fd94aa2cf9c-aura-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8a368916f5954036af3c9fd94aa2cf9c</projectId>-->
<!--<branchName>aura-space</branchName>-->